### PR TITLE
perms: make '-c' required for batch mode

### DIFF
--- a/src/commands/perms
+++ b/src/commands/perms
@@ -26,23 +26,24 @@ Examples:
     ssh git@host perms my/repo + WRITERS bob
 
 ----
-There is also a batch mode useful for scripting and bulk loading.  Do not
-combine this with the +/- mode above.  This mode also accepts an optional "-c"
-flag to create the repo if it does not already exist (assuming $GL_USER has
-permissions to create it).
-
-Examples:
-    cat copy-of-backed-up-gl-perms | ssh git@host perms <repo>
-    cat copy-of-backed-up-gl-perms | ssh git@host perms -c <repo>
+There is also a batch mode useful for scripting and bulk loading; see the
+source code of the perms command for details.
 =cut
 
-usage() if not @ARGV or $ARGV[0] eq '-h';
+# BATCH MODE: DO NOT combine this with the +/- mode above.  This mode also
+# creates the repo if it does not already exist (assuming $GL_USER has
+# permissions to create it).
+#
+# Example:
+#     cat copy-of-backed-up-gl-perms | ssh git@host perms -c <repo>
+
+usage() if not @ARGV or $ARGV[0] eq '-h' or @ARGV < 2;
 
 $ENV{GL_USER} or _die "GL_USER not set";
 
 my $generic_error = "repo does not exist, or you are not authorised";
 
-if ( @ARGV >= 2 and $ARGV[1] eq '-l' ) {
+if ( $ARGV[1] eq '-l' ) {
     getperms($ARGV[0]);    # doesn't return
 }
 

--- a/src/triggers/repo-specific-hooks
+++ b/src/triggers/repo-specific-hooks
@@ -34,6 +34,9 @@ while (<>) {
     $hook =~ s/^gitolite-options\.hook\.//;
     $hook =~ s/\..*//;
 
+    my @codes = split /\s+/, $codes;
+    next unless @codes;
+
     # this is a special case
     if ( $repo eq 'gitolite-admin' and $hook eq 'post-update' ) {
         _warn "repo-specific-hooks: ignoring attempts to set post-update hook for the admin repo";
@@ -46,7 +49,6 @@ while (<>) {
         next;
     }
 
-    my @codes = split /\s+/, $codes;
     push @{ $repo_hooks{$repo}{$hook} }, @codes if @codes;
 }
 

--- a/t/perm-default-roles.t
+++ b/t/perm-default-roles.t
@@ -139,7 +139,7 @@ try "cd $od";
 
 # add perms to an old repo
 try "
-echo WRITERS \@h1 | glt perms u1 foo/u1/u1r1
+echo WRITERS \@h1 | glt perms u1 -c foo/u1/u1r1
 ";
 
 try "cd $rb; find . -name gl-perms";

--- a/t/perm-roles.t
+++ b/t/perm-roles.t
@@ -63,7 +63,7 @@ glt push u1 file:///foo/u1/u1r1 t1
         POK; /\\[new tag\\]         t1 -> t1/
 
 # add u2 to WRITERS
-echo WRITERS \@g2 | glt perms u1 foo/u1/u1r1
+echo WRITERS \@g2 | glt perms u1 -c foo/u1/u1r1
 glt perms u1 foo/u1/u1r1 -l
         /WRITERS \@g2/
 
@@ -95,7 +95,7 @@ glt push u2 file:///foo/u1/u1r1 t2
         reject
 
 # change u2 to READERS
-echo READERS u2 | glt perms u1 foo/u1/u1r1
+echo READERS u2 | glt perms u1 -c foo/u1/u1r1
 glt perms u1 foo/u1/u1r1 -l
         /READERS u2/
 
@@ -108,7 +108,7 @@ glt push u2 file:///foo/u1/u1r1 master:master
         /W any foo/u1/u1r1 u2 DENIED by fallthru/
 
 # add invalid category MANAGERS
-    /usr/bin/printf 'READERS u6\\nMANAGERS u2\\n' | glt perms u1 foo/u1/u1r1
+    /usr/bin/printf 'READERS u6\\nMANAGERS u2\\n' | glt perms u1 -c foo/u1/u1r1
         !ok
         /Invalid role 'MANAGERS'/
 ";
@@ -120,7 +120,7 @@ put "$ENV{HOME}/g3trc", "\$rc{ROLES}{MANAGERS} = 1;\n";
 try "
     ENV G3T_RC=$ENV{HOME}/g3trc
     gitolite compile;   ok or die compile failed
-    /usr/bin/printf 'READERS u6\\nMANAGERS u2\\n' | glt perms u1 foo/u1/u1r1
+    /usr/bin/printf 'READERS u6\\nMANAGERS u2\\n' | glt perms u1 -c foo/u1/u1r1
                             ok;    !/Invalid role 'MANAGERS'/
     glt perms u1 foo/u1/u1r1 -l
 ";
@@ -156,7 +156,7 @@ glt push u2 file:///foo/u1/u1r1 t3
         POK; /\\[new tag\\]         t3 -> t3/
 
 # add invalid category TESTERS
-echo TESTERS u2 | glt perms u1 foo/u1/u1r1
+echo TESTERS u2 | glt perms u1 -c foo/u1/u1r1
         !ok
         /Invalid role 'TESTERS'/
 ";
@@ -167,7 +167,7 @@ put "|cat >> $ENV{HOME}/g3trc", "\$rc{ROLES}{TESTERS} = 1;\n";
 try "
 gitolite compile;   ok or die compile failed
 # add u2 to now valid TESTERS
-echo TESTERS u2 | glt perms u1 foo/u1/u1r1
+echo TESTERS u2 | glt perms u1 -c foo/u1/u1r1
         !/Invalid role 'TESTERS'/
 glt perms u1 foo/u1/u1r1 -l
 ";

--- a/t/perms-groups.t
+++ b/t/perms-groups.t
@@ -41,7 +41,7 @@ try "
         !/R W *\tbar/u1/try1\tu1/
 
     # \@leads can RW try1
-    echo WRITERS \@leads | glt perms u1 bar/u1/try1; ok
+    echo WRITERS \@leads | glt perms u1 -c bar/u1/try1; ok
     glt info u1 -lc
         /R W *\tbar/u1/try1\tu1/
     glt info u2 -lc
@@ -50,7 +50,7 @@ try "
         !/R W *\tbar/u1/try1\tu1/
 
     # \@devs can R try1
-    echo READERS \@devs | glt perms u1 bar/u1/try1; ok
+    echo READERS \@devs | glt perms u1 -c bar/u1/try1; ok
     glt perms u1 bar/u1/try1 -l
         /READERS \@devs/
         !/WRITERS \@leads/
@@ -67,7 +67,7 @@ try "
         /R *\tbar/u1/try1\tu1/
 
 # combo of previous 2
-    /usr/bin/printf 'READERS \@devs\\nWRITERS \@leads\\n' | glt perms u1 bar/u1/try1; ok
+    /usr/bin/printf 'READERS \@devs\\nWRITERS \@leads\\n' | glt perms u1 -c bar/u1/try1; ok
     glt perms u1 bar/u1/try1 -l
         /READERS \@devs/
         /WRITERS \@leads/

--- a/t/sequence.t
+++ b/t/sequence.t
@@ -33,7 +33,7 @@ try "
     glt push u1 origin master
         /To file:///foo/u1/bar/
         /\\[new branch\\]      master -> master/
-    echo WRITERS u2 | glt perms u1 foo/u1/bar
+    echo WRITERS u2 | glt perms u1 -c foo/u1/bar
     glt perms u1 foo/u1/bar -l
         /WRITERS u2/
     # expand
@@ -77,7 +77,7 @@ try "
     glt push u1 origin master
         /To file:///foo/u1/bar/
         /\\[new branch\\]      master -> master/
-    echo WRITERS u2 | glt perms u1 foo/u1/bar
+    echo WRITERS u2 | glt perms u1 -c foo/u1/bar
     glt perms u1 foo/u1/bar -l
         /WRITERS u2/
     # expand


### PR DESCRIPTION
Go to http://gitolite.com/gitolite/index.html#contact for information on
contacting me, the mailing list, and IRC channel.  *Unless you are reporting
what you think is a security issue, I prefer you send to the mailing list,
not to me directly.*

Please DO NOT send messages via github's "issues" system, linkedin
comments/discussion, stackoverflow questions, google+, and any other Web 3.0
"coolness". (The issues system does have an email interface, but it is not a
substitute for email. I can't cc anyone else when I want to, for instance.
Well I can, but any response the original requester then makes using the
website will not get cc-d to the person I cc-d).

Please send patches *via email*, not as github pull requests. Again, if you
think it's a security issue, send it directly to my gmail address, but
otherwise please send it to the mailing list, so others can see it and comment
on it.

The preferred format is the files created by git-format-patch, as attachments.
However, if your repo has a public clone URL, you can make a new branch just
for this fix, and send the repo URL and branch name to the mailing list.

(If you do send me a github pull request, I may take it if it's a trivial
patch, but otherwise I'll ask you to close the pull request, then read
this URL for how to send me the patch.)

quoth Tony:

>   Typing ^C at a command to make it stop without doing anything is a natural
>   reaction, regardless of any imprecations to type "cancel"

He asked for a '-b' option; i.e., don't allow a bare "ssh git@... perms repo"
to be interpreted as batch mode.

Meanwhile, '-c' is acceptable for existing repos too (as you can see from the
mirroring code at least).

So, just think of '-c' as a moral eqvt of '-b' that already exists.